### PR TITLE
[#84] Fix : Fix kakao token to be stored in cookie

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -47,7 +47,7 @@ class KakaoSignInView(APIView):
 
 # 카카오 회원가입+로그인 : 콜백
 class KaKaoSignInCallBackView(APIView):
-    def get(self, request):
+    def post(self, request):
 
         create_data = {
             'grant_type': 'authorization_code',

--- a/api/views.py
+++ b/api/views.py
@@ -34,9 +34,6 @@ def get_magazine_brand(magazines):
     return brand_list
 
 
-kakao_access_token = ""
-
-
 # 카카오 회원가입+로그인
 class KakaoSignInView(APIView):
     def get(self, request):
@@ -102,6 +99,7 @@ class KaKaoSignInCallBackView(APIView):
         })
 
         res.set_cookie('refresh', str(refresh_token), httponly=True)
+        res.set_cookie('kakao', kakao_access_token, httponly=True)
 
         return res
 
@@ -113,9 +111,11 @@ class KakaoSignOutView(APIView):
     def post(self, request):
 
         try:
+            kakao = request.COOKIES.get('kakao')
+
             kakao_token_logout = requests.post(
                 'https://kapi.kakao.com/v1/user/logout',
-                headers={"Authorization": f'Bearer {kakao_access_token}'}
+                headers={"Authorization": f'Bearer {kakao}'}
             )
 
             refresh = request.COOKIES.get('refresh')
@@ -129,6 +129,7 @@ class KakaoSignOutView(APIView):
                 })
 
                 res.delete_cookie('refresh')
+                res.delete_cookie('kakao')
 
             return res
 


### PR DESCRIPTION
## 📝 PR Summary
<!-- PR 한줄 요약 -->
카카오 토큰 저장 위치 쿠키로 수정 + 회원가입/로그인 api 호출 방식 수정

#### 🌲 Working Branch
<!-- 작업 브랜치 이름 -->
feature/kakao-auth-logout

#### ✅ TODOs
<!-- PR 작업한 내용 -->
- [x] 카카오 토큰 저장 위치 쿠키로 수정

### Related Issues
<!-- PR 연관 이슈 -->
* resolves #84